### PR TITLE
feat: support uploading to a directory

### DIFF
--- a/wolkenbrot/util.py
+++ b/wolkenbrot/util.py
@@ -145,6 +145,9 @@ class SSHClient:  # pragma: no coverage
         if os.path.isdir(src):
             self._copy_dir(src, dest)
         else:
+            # If dest is a directory (ends with /), append the source filename
+            if dest.endswith("/"):
+                dest = dest + os.path.basename(src)
             self._mkdir_p(os.path.dirname(dest))
             self.sftp.put(src, dest)
 


### PR DESCRIPTION
Now when the destination ends with / (like /tmp/), it will append the source filename automatically:

  ../bin/02-install-kubeadm.sh → /tmp/ becomes /tmp/02-install-kubeadm.sh